### PR TITLE
adds addon_config.mk for successful linux linking

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ cp -f ../../../addons/ofxLeapMotion2/libs/lib/osx/libLeap.dylib "$TARGET_BUILD_D
 
 ### Linux ( command line )
 
-Simply add `ofxLeapMotion2` to the `addons.make` file of your project. Remember that `make RunDebug` or `make RunRelease` or `make run` won't work if you don't have exported the `OF_ROOT` path. Executing with `./bin/youirappname` will always work.
+Simply add `ofxLeapMotion2` to the `addons.make` file of your project. Remember that `make RunDebug` or `make RunRelease` or `make run` won't work if you don't have exported the `OF_ROOT` path. Executing with `./bin/yourappname` will always work.
 
 
 ## Developing ofxLeapMotion

--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ Then after renaming:
 
 Rename the project in Xcode (do not rename the .xcodeproj file in Finder!): Slow double click the project name and rename (Xcode4)
 
+### Linux ( command line )
+
+You can simply navigate to the project folder and use `make Debug`, `make Release` or `make` and then execute with `./bin/example` .
+If you have exported the `OF_ROOT` path you can also use `make RunDebug` or `make RunRelease` or `make run` ( othewise you will get an error on execution as it won't find the path of the linked .so )
 
 ### Adding ofxLeapMotion to an Existing Project
 
@@ -62,6 +66,9 @@ cp -f ../../../addons/ofxLeapMotion2/libs/lib/osx/libLeap.dylib "$TARGET_BUILD_D
 
    If you don't have this you'll see an error in the console: dyld: Library not loaded: @loader_path/libLeap.dylib
 
+### Linux ( command line )
+
+Simply add `ofxLeapMotion2` to the `addons.make` file of your project. Remember that `make RunDebug` or `make RunRelease` or `make run` won't work if you don't have exported the `OF_ROOT` path. Executing with `./bin/youirappname` will always work.
 
 
 ## Developing ofxLeapMotion

--- a/addon_config.mk
+++ b/addon_config.mk
@@ -1,0 +1,94 @@
+# All variables and this file are optional, if they are not present the PG and the
+# makefiles will try to parse the correct values from the file system.
+#
+# Variables that specify exclusions can use % as a wildcard to specify that anything in
+# that position will match. A partial path can also be specified to, for example, exclude
+# a whole folder from the parsed paths from the file system
+#
+# Variables can be specified using = or +=
+# = will clear the contents of that variable both specified from the file or the ones parsed
+# from the file system
+# += will add the values to the previous ones in the file or the ones parsed from the file 
+# system
+# 
+# The PG can be used to detect errors in this file, just create a new project with this addon 
+# and the PG will write to the console the kind of error and in which line it is
+
+meta:
+	ADDON_NAME = ofxLeapMotion2
+	ADDON_DESCRIPTION = Leap Motion 2 wrapper
+	ADDON_AUTHOR = Gene Kogan
+	ADDON_TAGS = "Leap Motion" "NI"
+	ADDON_URL = https://github.com/genekogan/ofxLeapMotion2.git  
+
+common:
+	# dependencies with other addons, a list of them separated by spaces 
+	# or use += in several lines
+	# ADDON_DEPENDENCIES =
+	
+	# include search paths, this will be usually parsed from the file system
+	# but if the addon or addon libraries need special search paths they can be
+	# specified here separated by spaces or one per line using +=
+	# ADDON_INCLUDES =
+	
+	# any special flag that should be passed to the compiler when using this
+	# addon
+	# ADDON_CFLAGS =
+	
+	# any special flag that should be passed to the linker when using this
+	# addon, also used for system libraries with -lname
+	# ADDON_LDFLAGS =
+	
+	# linux only, any library that should be included in the project using
+	# pkg-config
+	# ADDON_PKG_CONFIG_LIBRARIES =
+	
+	# osx/iOS only, any framework that should be included in the project
+	# ADDON_FRAMEWORKS =
+	
+	# source files, these will be usually parsed from the file system looking
+	# in the src folders in libs and the root of the addon. if your addon needs
+	# to include files in different places or a different set of files per platform
+	# they can be specified here
+	# ADDON_SOURCES =
+	
+	# some addons need resources to be copied to the bin/data folder of the project
+	# specify here any files that need to be copied, you can use wildcards like * and ?
+	# ADDON_DATA = 
+	
+	# when parsing the file system looking for libraries exclude this for all or
+	# a specific platform
+	# ADDON_LIBS_EXCLUDE =
+	
+	# when parsing the file system looking for sources exclude this for all or
+	# a specific platform
+	# ADDON_SOURCES_EXCLUDE = 
+	
+	# when parsing the file system looking for include paths exclude this for all or
+	# a specific platform
+	# ADDON_INCLUDES_EXCLUDE =
+	
+linux64:
+	ADDON_LDFLAGS = ${OF_ROOT}/addons/ofxLeapMotion2/libs/lib/linux/libLeap.so
+	ADDON_LDFLAGS += -Wl,-rpath=${OF_ROOT}/addons/ofxLeapMotion2/libs/lib/linux
+	
+linux:
+	ADDON_LDFLAGS = ${OF_ROOT}/addons/ofxLeapMotion2/libs/lib/linux/libLeap.so
+	ADDON_LDFLAGS += -Wl,-rpath=${OF_ROOT}/addons/ofxLeapMotion2/libs/lib/linux
+	
+msys2:
+	
+vs:
+
+linuxarmv6l:
+	
+linuxarmv7l:
+
+android/armeabi:	
+		
+android/armeabi-v7a:	
+
+osx:
+    
+ios:
+


### PR DESCRIPTION
i've added an addon_config.mk file for successfully linking on linux. It works always when the user has a OF_ROOT variable set. Without it it works when the user compiles with make and then execute with ./bin/appname, but it doesn't work with "make run" or "make RunRelease". I've also added the instructions in the README.md file. Also thanks to @kashimAstro for pointing me in the right direction.