### PR TITLE
Replace Poco::FastMutex with std::mutex

### DIFF
--- a/src/ofxLeapMotion2.h
+++ b/src/ofxLeapMotion2.h
@@ -270,7 +270,7 @@ public:
     vector <Hand> getLeapHands(){
 		
         vector <Hand> handsCopy;
-        if( ourMutex.tryLock(2000) ){
+        if( ourMutex.try_lock() ){
             handsCopy = hands;
             ourMutex.unlock();
         }
@@ -434,7 +434,7 @@ protected:
     // TODO: added for Gesture support - JRW
     Leap::Frame lastFrame;
     
-    Poco::FastMutex ourMutex;
+    std::mutex ourMutex;
 };
 
 


### PR DESCRIPTION
This makes the addon compile with OpenFrameworks master branch. This comment suggests the change was also made in OF: https://forum.openframeworks.cc/t/building-for-android-problems-with-poco/21225/2