### PR TITLE
Updating Leap SDK URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ It is based on [Theo Watson's original ofxLeapMotion addon](https://github.com/o
 
 * Use of this addon requires a Developer License from LeapMotion see: https://www.leapmotion.com/developers
 
-* Once registered you should download and install the latest Leap Software from https://beta.leapmotion.com/ 
+* Once registered you should download and install the latest Leap Software from https://developer.leapmotion.com/sdk/v2 
 
 * To use ofxLeapMotion2, first you need to download and install [openFrameworks](https://github.com/openframeworks/openFrameworks).
 


### PR DESCRIPTION
Updating Leap v2 SDK download URL to point directly to the v2 page. Current URL points to newest SDK which is focused on  VR and Windows only.